### PR TITLE
Real Plume Compatibility

### DIFF
--- a/GameData/RocketSoundEnhancement/Patches/RealPlume.cfg
+++ b/GameData/RocketSoundEnhancement/Patches/RealPlume.cfg
@@ -91,7 +91,7 @@
 		@Kerolox_UpperEagle{!AUDIO{}}
 		
 		
-		@engage:NEEDS[RealismOverhaul]
+		@engage:NEEDS[!RealismOverhaul]
 		{
 			!AUDIO{}
 		}

--- a/GameData/RocketSoundEnhancement/Patches/RealPlume.cfg
+++ b/GameData/RocketSoundEnhancement/Patches/RealPlume.cfg
@@ -1,0 +1,111 @@
+// Every Part configured by RSE will have it's Real Plume sound deleted
+// If Realism Overhaul is installed, the engage sound will remain active, otherwise ignition it will be very silent
+
+@PART[*]:HAS[@MODULE[RSE_Engines]]:FOR[zzzRocketSoundEnhancement]:NEEDS[RealPlume]
+{
+	@EFFECTS
+	{
+		@CombinedPlume{!AUDIO{}}
+		
+		@Alcolox_Lower{!AUDIO{}}
+		@Ammonialox{!AUDIO{}}
+		@Cryogenic_LowerAblative_CE{!AUDIO{}}
+		@Cryogenic_LowerRed_CE{!AUDIO{}}
+		@Cryogenic_LowerSSME_CE{!AUDIO{}}
+		@Cryogenic_OrangeVernier{!AUDIO{}}
+		@Cryogenic_UpperBlue_CE{!AUDIO{}}
+		@HTP_RP1_lower{!AUDIO{}}
+		@Hydrolox_Aerospike{!AUDIO{}}
+		@Hydrolox_UpperBlue{!AUDIO{}}
+		@Hydynelox{!AUDIO{}}
+		@Hypergolic_Aerozine50Lower{!AUDIO{}}
+		@Hypergolic-Apollo-SM{!AUDIO{}}
+		@Hypergolic-Lower{!AUDIO{}}
+		@Hypergolic-OMS-White{!AUDIO{}}
+		@Hypergolic-Vernier{!AUDIO{}}
+		@Hypergolic_LowerOrangeShock{!AUDIO{}}
+		@Hypergolic_LowerRed_shock{!AUDIO{}}
+		@Hypergolic_UpperAerozine{!AUDIO{}}
+		@Hypergolic_UpperOrange{!AUDIO{}}
+		@Hypergolic_UpperRed{!AUDIO{}}
+		@Hypergolic_UpperWhite{!AUDIO{}}
+		@Hypergolic_UpperYellow{!AUDIO{}}
+		@Hypergolic_VernierOrange{!AUDIO{}}
+		@Hypergolic_VernierRed{!AUDIO{}}
+		@Ion_Argon_Gridded_NFP{!AUDIO{}}
+		@Ion_Argon_Hall_NFP{!AUDIO{}}
+		@Ion_Xenon_Gridded_NFP{!AUDIO{}}
+		@Ion_Xenon_Hall_NFP{!AUDIO{}}
+		@Kerolox-Exhaust{!AUDIO{}}
+		@Kerolox_LowerAlt{!AUDIO{}}
+		@Kerolox_LowerAspirated{!AUDIO{}}
+		@Kerolox_LowerFlame{!AUDIO{}}
+		@Kerolox_LowerNK33{!AUDIO{}}
+		@Kerolox_SL_FilmCooled{!AUDIO{}}
+		@Kerolox_TurboExhaust{!AUDIO{}}
+		@Kerolox_Upper{!AUDIO{}}
+		@Kerolox_VernierEagle{!AUDIO{}}
+		@MagnetoPlasmaDynamicThruster{!AUDIO{}}
+		@Methalox_AirBreathingMode{!AUDIO{}}
+		@Methalox_Lower{!AUDIO{}}
+		@Methalox_LowerShock{!AUDIO{}}
+		@Methalox_Upper{!AUDIO{}}
+		@Nuclear_GasCore_LH2{!AUDIO{}}
+		@Nuclear_GasCore_Open_LH2{!AUDIO{}}
+		@Nuclear_SolidCore_LH2{!AUDIO{}}
+		@Nuclear_SolidCore_LOX{!AUDIO{}}
+		@Nuclear_VernierExhaust{!AUDIO{}}
+		@Penataborane_Lower{!AUDIO{}}
+		@PulsedInductiveThruster_Argon{!AUDIO{}}
+		@Solid-LES{!AUDIO{}}
+		@Solid-Lower{!AUDIO{}}
+		@Solid-Sepmotor{!AUDIO{}}
+		@Solid-Upper{!AUDIO{}}
+		@Solid-Vacuum{!AUDIO{}}
+		@Turbofan{!AUDIO{}}
+		@TurbofanOxPlume{!AUDIO{}}
+		@Turbojet{!AUDIO{}}
+		@TurbojetOxPlume{!AUDIO{}}
+		@VASIMIR_Argon{!AUDIO{}}
+		@VASIMIR_Xenon{!AUDIO{}}
+		
+		@Alcolox-Lower-A6{!AUDIO{}}
+		@Cryogenic-UpperLower-125{!AUDIO{}}
+		@Cryogenic-UpperLower-25{!AUDIO{}}
+		@Cryogenic-UpperLower-375{!AUDIO{}}
+		@Hydrogen-NTR-HighTemp{!AUDIO{}}
+		@Hydrogen-NTR{!AUDIO{}}
+		@Hydrolox-Lower{!AUDIO{}}
+		@Hydrolox-Upper{!AUDIO{}}
+		@Hydrolox_LowerBlaze{!AUDIO{}}
+		@Hydynelox-A7 {!AUDIO{}}
+		@Hypergolic-OMS-Red{!AUDIO{}}
+		@Hypergolic-Upper{!AUDIO{}}
+		@Kerolox-Lower-F1{!AUDIO{}}
+		@Kerolox-Lower{!AUDIO{}}
+		@Kerolox-Upper{!AUDIO{}}
+		@Kerolox-Vernier{!AUDIO{}}
+		@Kerolox_LowerBlaze{!AUDIO{}}
+		@Kerolox_LowerIbis{!AUDIO{}}
+		@Kerolox_LowerSparrow{!AUDIO{}}
+		@Kerolox_UpperEagle{!AUDIO{}}
+		
+		
+		@engage:NEEDS[RealismOverhaul]
+		{
+			!AUDIO{}
+		}
+		
+		@disengage
+		{
+			!AUDIO{}
+		}
+	
+		@flameout
+		{
+			!AUDIO{}
+		}
+	
+	}
+  
+}


### PR DESCRIPTION
Currently the new version (0.5.x) of RSE lacks Real Plume compatibility, this patch aims to fix that.

When a part contains the **RSE_Engines** module, every sound added by realplume is deleted. This way, only RSE compatible engines will be affected.

In case Realism Overhaul is installed, the engage node will **NOT** be deleted, this is intentional because RSE lacks engage sounds right now and igniting something in RO is pretty weird without it. RO patches will be coming soon


This is my first public patch, I'm open to criticism and tips