### PR TITLE
Update AssmeblyInfo.cs

### DIFF
--- a/Source/RocketSoundEnhancement.Unity/Properties/AssemblyInfo.cs
+++ b/Source/RocketSoundEnhancement.Unity/Properties/AssemblyInfo.cs
@@ -34,3 +34,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: KSPAssembly("RocketSoundEnhancement.Unity", 1, 0)]

--- a/Source/RocketSoundEnhancement/Properties/AssemblyInfo.cs
+++ b/Source/RocketSoundEnhancement/Properties/AssemblyInfo.cs
@@ -31,3 +31,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersion("0.9.6.*")]
 [assembly: AssemblyInformationalVersion("0.9.6")]
 [assembly: KSPAssembly("RocketSoundEnhancement", 0, 9, 6)]
+[assembly: KSPAssemblyDependency("RocketSoundEnhancement.Unity", 1, 0)]


### PR DESCRIPTION
Part of a fix for a KSP bug that will probably never be solved officially.
"ADDON BINDER: Cannot resolve assembly" in KSP.log
Doesn't really do anything for functionality, but preventing the error makes sure everything that loads after is alright