### PR TITLE
perf: Optimize `RocketSoundEnhancement.LateUpdate` by patching `AudioSource` ctor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,3 +14,5 @@ on:
 jobs:
   build:
     uses: KSPModdingLibs/KSPBuildTools/.github/workflows/build.yml@0.0.4
+    with:
+      dependency-identifiers: Harmony2

--- a/Source/RocketSoundEnhancement/Patches/AudioSource_Patch.cs
+++ b/Source/RocketSoundEnhancement/Patches/AudioSource_Patch.cs
@@ -1,0 +1,17 @@
+using HarmonyLib;
+using UnityEngine;
+using System;
+
+namespace RocketSoundEnhancement.Patches
+{
+    [HarmonyPatch(typeof(AudioSource), MethodType.Constructor, argumentTypes: new Type[0])]
+    internal static class AudioSource_Ctor_Patch
+    {
+        static void Postfix(AudioSource __instance)
+        {
+            RocketSoundEnhancement.Instance?.newAudioSources?.Add(__instance);
+        }
+    }
+}
+
+

--- a/Source/RocketSoundEnhancement/RocketSoundEnhancement.csproj
+++ b/Source/RocketSoundEnhancement/RocketSoundEnhancement.csproj
@@ -7,26 +7,34 @@
 		<Publicize Include="Assembly-CSharp" IncludeCompilerGeneratedMembers="false" />
 	</ItemGroup>
 
-  <PropertyGroup>
-    <BinariesOutputRelativePath>GameData\RocketSoundEnhancement\Plugins</BinariesOutputRelativePath>
-    <GenerateKSPAssemblyAttribute>true</GenerateKSPAssemblyAttribute>
-    <GenerateKSPAssemblyDependencyAttributes>true</GenerateKSPAssemblyDependencyAttributes>
-  </PropertyGroup>
+	<PropertyGroup>
+		<BinariesOutputRelativePath>GameData\RocketSoundEnhancement\Plugins</BinariesOutputRelativePath>
+		<GenerateKSPAssemblyAttribute>true</GenerateKSPAssemblyAttribute>
+		<GenerateKSPAssemblyDependencyAttributes>true</GenerateKSPAssemblyDependencyAttributes>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\RocketSoundEnhancement.Unity\RocketSoundEnhancement.Unity.csproj">
-      <Project>{5dff0176-7ba8-49f4-8155-f5d9b37d7d3d}</Project>
-      <Name>RocketSoundEnhancement.Unity</Name>
-      <Private>False</Private>
-    </ProjectReference>
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference
+			Include="..\RocketSoundEnhancement.Unity\RocketSoundEnhancement.Unity.csproj">
+			<Project>{5dff0176-7ba8-49f4-8155-f5d9b37d7d3d}</Project>
+			<Name>RocketSoundEnhancement.Unity</Name>
+			<Private>False</Private>
+		</ProjectReference>
+	</ItemGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Krafs.Publicizer" Version="2.3.0">
-		  <PrivateAssets>all</PrivateAssets>
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="KSPBuildTools" Version="0.0.4" />
+
+		<Reference Include="HarmonyKSP">
+			<HintPath>$(KSPRoot)/GameData/000_Harmony/0Harmony.dll</HintPath>
+			<Private>false</Private>
+			<KSPAssembly>HarmonyKSP</KSPAssembly>
+			<KSPAssemblyVersion>2.2.1</KSPAssemblyVersion>
+		</Reference>
 	</ItemGroup>
 
 </Project>

--- a/Source/RocketSoundEnhancement/Startup.cs
+++ b/Source/RocketSoundEnhancement/Startup.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using HarmonyLib;
 using UnityEngine;
 
 namespace RocketSoundEnhancement
@@ -15,7 +11,7 @@ namespace RocketSoundEnhancement
             AudioConfiguration audioConfig = AudioSettings.GetConfiguration();
             audioConfig.numRealVoices = Settings.VoiceCount;
 
-            if(AudioSettings.Reset(audioConfig)) {
+            if (AudioSettings.Reset(audioConfig)) {
                 Debug.Log("[RSE]: Audio Settings Applied");
                 Debug.Log("[RSE]: DSP Buffer Size : " + AudioSettings.GetConfiguration().dspBufferSize);
                 Debug.Log("[RSE]: Real Voices : " +     AudioSettings.GetConfiguration().numRealVoices);
@@ -23,6 +19,9 @@ namespace RocketSoundEnhancement
                 Debug.Log("[RSE]: Samplerate : " +      AudioSettings.GetConfiguration().sampleRate);
                 Debug.Log("[RSE]: Spearker Mode : " +   AudioSettings.GetConfiguration().speakerMode);
             }
+
+            Harmony harmony = new Harmony("RocketSoundEnhancement");
+            harmony.PatchAll(typeof(Startup).Assembly);
         }
     }
 }


### PR DESCRIPTION
Every frame, RocketSoundEnhancement makes a FindObjectsOfType call in order to discover any new AudioSources that have been created in the last frame. This is slow.

This commit does away with that by:
- Patching AudioSource::.ctor to add the newly created AudioSource object to a list (if there is currently an instance of RocketSoundEnhancement active).
- Processing the new items in the list in LateUpdate instead of checking all available items.

There might be some further simplifications that can be done here now that we know that we're only processing new AudioSources. None of them would have an effect on performance though, so I have left them in just to be safe.

In my testing this change reduces the time spent in RSE.LateUpdate from 4.4s to 90ms over a 253s launch to orbit.

In addition to the optimization itself, I have also:
- Added Harmony2 as a dependency in the csproj
- Updated CI to install harmony2