### PR TITLE
ShipEffects: skip heavy Initialize for debris vessels

### DIFF
--- a/Source/RocketSoundEnhancement/ShipEffects.cs
+++ b/Source/RocketSoundEnhancement/ShipEffects.cs
@@ -65,14 +65,13 @@ namespace RocketSoundEnhancement
                 noPhysics = vessel.Parts[0].PhysicsSignificance == 1;
                 return true;
             }
-			// Debris vessels have no engines, no command modules — nothing useful to play sounds for.
-            // Reinit if vesselType promotes (e.g. kerbal boards a stranded vessel).
+
+            // Debris vessels have no engines, no command modules — nothing useful to play sounds for.
             if (vessel.vesselType == VesselType.Debris ||
                 vessel.vesselType == VesselType.SpaceObject ||
                 vessel.vesselType == VesselType.DroppedPart)
             {
                 ignoreVessel = true;
-                GameEvents.onVesselTypeChange.Add(OnVesselTypeChange);
                 return true;
             }
 
@@ -148,19 +147,6 @@ namespace RocketSoundEnhancement
 
             CacheVesselData();
         }
-		private void OnVesselTypeChange(Vessel data, VesselType newType)
-        {
-            if (data != vessel) return;
-            if (newType == VesselType.Debris ||
-                newType == VesselType.SpaceObject ||
-                newType == VesselType.DroppedPart)
-                return;
-
-            GameEvents.onVesselTypeChange.Remove(OnVesselTypeChange);
-            ignoreVessel = false;
-            initialized = false;
-            initialized = Initialize();
-        }
 
 		IEnumerator SetupAudioSources(List<SoundLayer> soundLayers, bool hasAirSimFilter = true)
         {
@@ -212,7 +198,6 @@ namespace RocketSoundEnhancement
             asteroidParts.Clear();
             engines.Clear();
             GameEvents.onVesselPartCountChanged.Remove(OnVesselPartCountChanged);
-			GameEvents.onVesselTypeChange.Remove(OnVesselTypeChange);
 
             initialized = false;
         }

--- a/Source/RocketSoundEnhancement/ShipEffects.cs
+++ b/Source/RocketSoundEnhancement/ShipEffects.cs
@@ -65,6 +65,16 @@ namespace RocketSoundEnhancement
                 noPhysics = vessel.Parts[0].PhysicsSignificance == 1;
                 return true;
             }
+			// Debris vessels have no engines, no command modules — nothing useful to play sounds for.
+            // Reinit if vesselType promotes (e.g. kerbal boards a stranded vessel).
+            if (vessel.vesselType == VesselType.Debris ||
+                vessel.vesselType == VesselType.SpaceObject ||
+                vessel.vesselType == VesselType.DroppedPart)
+            {
+                ignoreVessel = true;
+                GameEvents.onVesselTypeChange.Add(OnVesselTypeChange);
+                return true;
+            }
 
             if (ShipEffectsConfig.ShipEffectsConfigNode.Count > 0)
             {
@@ -138,6 +148,19 @@ namespace RocketSoundEnhancement
 
             CacheVesselData();
         }
+		private void OnVesselTypeChange(Vessel data, VesselType newType)
+        {
+            if (data != vessel) return;
+            if (newType == VesselType.Debris ||
+                newType == VesselType.SpaceObject ||
+                newType == VesselType.DroppedPart)
+                return;
+
+            GameEvents.onVesselTypeChange.Remove(OnVesselTypeChange);
+            ignoreVessel = false;
+            initialized = false;
+            initialized = Initialize();
+        }
 
 		IEnumerator SetupAudioSources(List<SoundLayer> soundLayers, bool hasAirSimFilter = true)
         {
@@ -189,6 +212,7 @@ namespace RocketSoundEnhancement
             asteroidParts.Clear();
             engines.Clear();
             GameEvents.onVesselPartCountChanged.Remove(OnVesselPartCountChanged);
+			GameEvents.onVesselTypeChange.Remove(OnVesselTypeChange);
 
             initialized = false;
         }


### PR DESCRIPTION
Hi,

Was profiling KSP with dotTrace and found a ~150-200ms main-thread hitch every time a part is destroyed or separated in vacuum. Tracked it down to ShipEffects.

When a Separator or any decoupler-style event fires in vacuum, KSP creates a new Vessel for each separated subassembly. On a typical multi-stage rocket that's 3-5 new Vessels in one frame. Each new Vessel instantiates ShipEffects (VesselModule, order 999), and on first OnLoadVessel runs the full Initialize - parses every SoundLayer config, calls GameDatabase.GetAudioClip for each clip, allocates new GameObject for audioParent. Around 33 sound layers per vessel times 5 vessels per separation event = ~150-200ms main thread stall.

The thing is, debris vessels don't need this. They have no engines, no command modules, no useful sound source. A drifting decoupler in space should not be running an audio engine init.

ShipEffects already has an early-exit for single-part vessels (asteroid/EVA fast path) but multi-part debris falls through.

dotTrace stack attached below.

Fix adds a debris check after the single-part exit in Initialize, plus a VesselTypeChange handler so debris that promotes to a real vessel, kerbal boarding a stranded vessel for example, gets a clean reinit. Mirrors the existing single-part asteroid/EVA fast path - sets ignoreVessel=true and returns early. Both FixedUpdate and LateUpdate already short-circuit on ignoreVessel, so debris stay silent the same way asteroids do today (the `if (ignoreVessel && controlGroup != PhysicsControl.SONICBOOM)` line in the parsing loop has no runtime effect anyway since LateUpdate exits on ignoreVessel before reaching the SonicBoom code).

Tested locally with a Harmony prefix doing the same thing - separation hitch is gone, normal vessels still init as before.

Thanks!

<img width="875" height="552" alt="{2D79F6EA-2BFE-441B-B02D-5BADE686828C}" src="https://github.com/user-attachments/assets/d25a4e39-848c-401f-ad1d-22c643658351" />